### PR TITLE
Fix check for cwd/lr.Dir being set

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -126,7 +126,7 @@ func MaybeBecomeChildProcess() {
 			log.Fatalf("failed to Setuid(%d): %v", lr.Uid, err)
 		}
 	}
-	if lr.Path != "" {
+	if lr.Dir != "" {
 		err = os.Chdir(lr.Dir)
 		if err != nil {
 			log.Fatalf("failed to chdir to %q: %v", lr.Dir, err)


### PR DESCRIPTION
An empty cwd will currently cause the child process to exit with status 1. This patch makes it ignore empty cwd.
